### PR TITLE
User can override MQTT topic

### DIFF
--- a/ESPController/include/defines.h
+++ b/ESPController/include/defines.h
@@ -47,6 +47,7 @@ struct diybms_eeprom_settings {
 
   //NOTE this array is subject to buffer overflow vulnerabilities!
   bool mqtt_enabled;
+  char mqtt_topic[32+1];
   uint16_t mqtt_port;
   char mqtt_server[64+1];
   char mqtt_username[32+1];

--- a/ESPController/include/html_1.h
+++ b/ESPController/include/html_1.h
@@ -165,6 +165,10 @@ const char FILE_INDEX_HTML[] PROGMEM = R"=====(
                 <input type="checkbox" name="mqttEnabled" id="mqttEnabled">
             </div>
             <div>
+                <label for="mqttTopic">Topic</label>
+                <input type="input" name="mqttTopic" id="mqttTopic" value="diybms" required="" maxlength="32">
+            </div>
+            <div>
                 <label for="mqttServer">Server</label>
                 <input type="input" name="mqttServer" id="mqttServer" value="" required="" maxlength="64">
             </div>
@@ -814,6 +818,7 @@ $(function() {
       function(data) {
 
           $("#mqttEnabled").prop("checked", data.mqtt.enabled );
+          $("#mqttTopic").val(data.mqtt.topic);
           $("#mqttServer").val(data.mqtt.server);
           $("#mqttPort").val(data.mqtt.port);
           $("#mqttUsername").val(data.mqtt.username);

--- a/ESPController/src/DIYBMSServer.cpp
+++ b/ESPController/src/DIYBMSServer.cpp
@@ -259,30 +259,36 @@ void DIYBMSServer::saveMQTTSetting(AsyncWebServerRequest *request) {
 
     if (request->hasParam("mqttEnabled", true)) {
       AsyncWebParameter *p1 = request->getParam("mqttEnabled", true);
-      mysettings.mqtt_enabled =p1->value().equals("on") ? true:false;
+      mysettings.mqtt_enabled = p1->value().equals("on") ? true:false;
     } else {
-      mysettings.mqtt_enabled =false;
+      mysettings.mqtt_enabled = false;
     }
 
-    if (request->hasParam("mqttEnabled", true)) {
+    if (request->hasParam("mqttTopic", true)) {
+      AsyncWebParameter *p1 = request->getParam("mqttTopic", true);
+      p1->value().toCharArray(mysettings.mqtt_topic, sizeof(mysettings.mqtt_topic));
+    } else {
+      sprintf(mysettings.mqtt_topic, "diybms");
+    }
+
+    if (request->hasParam("mqttPort", true)) {
       AsyncWebParameter *p1 = request->getParam("mqttPort", true);
-      mysettings.mqtt_port =p1->value().toInt();
+      mysettings.mqtt_port = p1->value().toInt();
     }
-
 
     if (request->hasParam("mqttServer", true)) {
       AsyncWebParameter *p1 = request->getParam("mqttServer", true);
-      p1->value().toCharArray(mysettings.mqtt_server,sizeof(mysettings.mqtt_server));
+      p1->value().toCharArray(mysettings.mqtt_server, sizeof(mysettings.mqtt_server));
     }
 
     if (request->hasParam("mqttUsername", true)) {
       AsyncWebParameter *p1 = request->getParam("mqttUsername", true);
-      p1->value().toCharArray(mysettings.mqtt_username,sizeof(mysettings.mqtt_username));
+      p1->value().toCharArray(mysettings.mqtt_username, sizeof(mysettings.mqtt_username));
     }
 
     if (request->hasParam("mqttPassword", true)) {
       AsyncWebParameter *p1 = request->getParam("mqttPassword", true);
-      p1->value().toCharArray(mysettings.mqtt_password,sizeof(mysettings.mqtt_password));
+      p1->value().toCharArray(mysettings.mqtt_password, sizeof(mysettings.mqtt_password));
     }
 
     Settings::WriteConfigToEEPROM((char*)&mysettings, sizeof(mysettings), EEPROM_SETTINGS_START_ADDRESS);
@@ -523,10 +529,11 @@ void DIYBMSServer::integration(AsyncWebServerRequest *request) {
   JsonObject root = doc.to<JsonObject>();
 
   JsonObject mqtt = root.createNestedObject("mqtt");
-  mqtt["enabled"] =mysettings.mqtt_enabled;
-  mqtt["port"] =mysettings.mqtt_port;
-  mqtt["server"] =mysettings.mqtt_server;
-  mqtt["username"] =mysettings.mqtt_username;
+  mqtt["enabled"] = mysettings.mqtt_enabled;
+  mqtt["topic"] = mysettings.mqtt_topic;
+  mqtt["port"] = mysettings.mqtt_port;
+  mqtt["server"] = mysettings.mqtt_server;
+  mqtt["username"] = mysettings.mqtt_username;
   //We don't output the password in the json file as this could breach security
   //mqtt["password"] =mysettings.mqtt_password;
 

--- a/ESPController/src/main.cpp
+++ b/ESPController/src/main.cpp
@@ -640,7 +640,7 @@ void sendMqttPacket() {
 
   Serial1.println("Sending MQTT");
 
-  char topic[50];
+  char topic[80];
   char jsonbuffer[100];
   //char value[20];
   //uint16_t reply;
@@ -650,12 +650,12 @@ void sendMqttPacket() {
 
       StaticJsonDocument<100> doc;
       doc["voltage"] = (float)cmi[bank][i].voltagemV/1000.0;
-      doc["inttemp"]=cmi[bank][i].internalTemp;
-      doc["exttemp"]=cmi[bank][i].externalTemp;
-      doc["bypass"]=cmi[bank][i].inBypass ? 1:0;
+      doc["inttemp"] = cmi[bank][i].internalTemp;
+      doc["exttemp"] = cmi[bank][i].externalTemp;
+      doc["bypass"] = cmi[bank][i].inBypass ? 1:0;
       serializeJson(doc, jsonbuffer, sizeof(jsonbuffer));
 
-      sprintf(topic, "diybms/%d/%d", bank,i);
+      sprintf(topic, "%s/%d/%d", mysettings.mqtt_topic, bank, i);
       mqttClient.publish(topic, 0, false, jsonbuffer);
       Serial1.println(topic);
       //Serial1.print(" ");      Serial1.print(jsonbuffer);      Serial1.print(" ");      Serial1.println(reply);
@@ -682,6 +682,7 @@ void LoadConfiguration() {
     mysettings.mqtt_port=1883;
 
     //Default to EMONPI default MQTT settings
+    strcpy(mysettings.mqtt_topic,"diybms");
     strcpy(mysettings.mqtt_server,"192.168.0.26");
     strcpy(mysettings.mqtt_username,"emonpi");
     strcpy(mysettings.mqtt_password,"emonpimqtt2016");


### PR DESCRIPTION
MQTT page has been updated to show topic as a textbox default filled with the standard topic "diybms" but this allows you to change it to something else (if for example you are using more than one controller and need to identify them separately).  There is also a bug fix in the DIYBMSServer::saveMQTTSetting code where one of the "if" statements was looking at the wrong value.